### PR TITLE
Updates to GenStage 0.6.1

### DIFF
--- a/lib/osteria/chef.ex
+++ b/lib/osteria/chef.ex
@@ -16,8 +16,8 @@ defmodule Osteria.Chef do
                                                max_demand: 5)
     {:producer_consumer, [],
      dispatcher: {GenStage.PartitionDispatcher,
-                  partitions: 4,
-                  hash: &partition/2}}
+                  partitions: Osteria.Menu.types,
+                  hash: &partition/1}}
   end
 
   def handle_events(orders, _from, state) do
@@ -55,7 +55,7 @@ defmodule Osteria.Chef do
     |> Keyword.get(:organizing_speed, @default_organizing_speed)
   end
 
-  defp partition({table_number, dish}, _line_cooks_total) do
-    {{table_number, dish}, Osteria.LineCook.partition(dish.type)}
+  defp partition({table_number, dish}) do
+    {{table_number, dish}, dish.type}
   end
 end

--- a/lib/osteria/line_cook.ex
+++ b/lib/osteria/line_cook.ex
@@ -17,7 +17,7 @@ defmodule Osteria.LineCook do
     :ok = GenStage.async_subscribe(self(), to: Osteria.Chef,
                                            min_demand: 3,
                                            max_demand: 5,
-                                           partition: partition(area))
+                                           partition: area)
     {:consumer, area}
   end
 

--- a/lib/osteria/menu.ex
+++ b/lib/osteria/menu.ex
@@ -18,6 +18,11 @@ defmodule Osteria.Menu do
     Enum.map(all(), &(&1.name))
   end
 
+  def types do
+    Enum.map(all(), &(&1.type))
+    |> Enum.uniq
+  end
+
   def find_by_name(name) do
     Enum.find(all(), fn(d) -> d.name == name end)
   end

--- a/mix.exs
+++ b/mix.exs
@@ -32,6 +32,6 @@ defmodule Osteria.Mixfile do
      {:cowboy, "~> 1.0.0"},
      {:poison, "~> 2.2"},
      {:plug, "~> 1.2"},
-     {:gen_stage, "~> 0.5.0"}]
+     {:gen_stage, "~> 0.6.0"}]
   end
 end

--- a/mix.lock
+++ b/mix.lock
@@ -3,7 +3,7 @@
   "exfswatch": {:hex, :exfswatch, "0.2.1", "3f34190e2750ae6d924ce53729bb40e050dd8a08fee683847e6ddfa03ea5429f", [:mix], [{:fs, "~> 0.9", [hex: :fs, optional: false]}]},
   "exsync": {:hex, :exsync, "0.1.3", "84c66a4f60505d1baeb8a79cbf713ae98276f23b4bc7d676c6cb2d663fced5f3", [:mix], [{:exfswatch, "~> 0.2.1", [hex: :exfswatch, optional: false]}]},
   "fs": {:hex, :fs, "0.9.2", "ed17036c26c3f70ac49781ed9220a50c36775c6ca2cf8182d123b6566e49ec59", [:rebar], []},
-  "gen_stage": {:hex, :gen_stage, "0.5.0", "758068f3a81286e342a609d668e9624714c2e4d43cc26699ead04d1680fde6c6", [:mix], []},
+  "gen_stage": {:hex, :gen_stage, "0.6.1", "1e05e3faf9e505dcdb1e6d2da501fc5d1724e7ea6176bf72853ea78c8a600d1c", [:mix], []},
   "mime": {:hex, :mime, "1.0.1", "05c393850524767d13a53627df71beeebb016205eb43bfbd92d14d24ec7a1b51", [:mix], []},
   "plug": {:hex, :plug, "1.2.0", "496bef96634a49d7803ab2671482f0c5ce9ce0b7b9bc25bc0ae8e09859dd2004", [:mix], [{:cowboy, "~> 1.0", [hex: :cowboy, optional: true]}, {:mime, "~> 1.0", [hex: :mime, optional: false]}]},
   "poison": {:hex, :poison, "2.2.0", "4763b69a8a77bd77d26f477d196428b741261a761257ff1cf92753a0d4d24a63", [:mix], []},


### PR DESCRIPTION
Line cooks are partitioned directly on the dish type, without the need
to map the type itself to an integer

Closes #1 
